### PR TITLE
Fix: Fixing page max content width

### DIFF
--- a/components/wrapper/Wrapper.jsx
+++ b/components/wrapper/Wrapper.jsx
@@ -1,6 +1,6 @@
 const Wrapper = ({children}) => {
     return ( 
-       <section className="xl:mx-auto xl:max-w-container xl:px-0 lg:px-9.5 px-5">
+       <section className="xl:mx-auto xl:max-w-container xl:w-89 xl:px-0 lg:px-9.5 px-5">
         {children}
        </section>
      );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -93,12 +93,13 @@ module.exports = {
         141.25: "35.3125rem",
         153.5: "38.375rem",
         239: "59.75rem",
+         89 : "89.17%"
       },
 
       maxWidth: {
         107.5: "26.875rem",
         147.5: "39.375rem",
-        container: "89.17%",
+        container: "89.17rem",
       },
 
       minWidth: {


### PR DESCRIPTION
## Describe your changes
Adding max page width in case the page is opened in bigger screens it pushed the content to the center
## Issue ticket number and link
- ID: #018
- Link: https://www.notion.so/apeunit/Fix-page-content-width-7200fdd10b1247b89e5f52257fa54b2f

## Tasks completed
- [x] Fixing the page content width

 
## Tasks not completed
- None

## Screenshots (if needed)

![image](https://user-images.githubusercontent.com/90575886/211859570-db972ca8-c86b-4229-a31e-6e2180a20d49.png)

