### PR TITLE
Fix: Partners section logos

### DIFF
--- a/components/sections/Partners.jsx
+++ b/components/sections/Partners.jsx
@@ -10,7 +10,7 @@ const Partners = () => {
       <Paragraph className="text-center text-secondary-200">
         We partner with the leading brands
       </Paragraph>
-      <div className="md:flex flex-wrap justify-center items-center hidden lg:mx-57.75">
+      <div className="md:flex flex-wrap justify-center mt-6 md:mt-4.75 items-center lg:mx-57.75">
         {logos.map((logo, index) => {
           return (
             <Link href={logo.link} key={index} target='_blank'>

--- a/components/sections/Partners.jsx
+++ b/components/sections/Partners.jsx
@@ -10,7 +10,7 @@ const Partners = () => {
       <Paragraph className="text-center text-secondary-200">
         We partner with the leading brands
       </Paragraph>
-      <div className="md:flex flex-wrap justify-center mt-6 md:mt-4.75 items-center lg:mx-57.75">
+      <div className="md:flex flex-wrap justify-center mt-6 md:mt-4.75 items-center hidden lg:mx-57.75">
         {logos.map((logo, index) => {
           return (
             <Link href={logo.link} key={index} target='_blank'>
@@ -29,7 +29,7 @@ const Partners = () => {
       <div className="flex flex-wrap justify-center w-full md:hidden">
         {logos.map((logo, index) => {
           return (
-            <div className="relative w-18.75 h-8.25 mx-1.5 my-2" key={index}>
+            <div className="relative w-11.25 h-8.25 mx-1.5 my-2" key={index}>
               <Link href={logo.link} target='_blank'><Image src={logo.source} priority fill alt="logo" /></Link>
             </div>
           );

--- a/components/sections/Partners.jsx
+++ b/components/sections/Partners.jsx
@@ -10,7 +10,7 @@ const Partners = () => {
       <Paragraph className="text-center text-secondary-200">
         We partner with the leading brands
       </Paragraph>
-      <div className="md:flex flex-wrap justify-center mt-6 md:mt-4.75 items-center hidden lg:mx-57.75">
+      <div className="md:flex flex-wrap justify-center mt-4.75 items-center hidden lg:mx-57.75">
         {logos.map((logo, index) => {
           return (
             <Link href={logo.link} key={index} target='_blank'>
@@ -26,7 +26,7 @@ const Partners = () => {
           );
         })}
       </div>
-      <div className="flex flex-wrap justify-center w-full md:hidden">
+      <div className="flex flex-wrap justify-center mt-6 w-full md:hidden">
         {logos.map((logo, index) => {
           return (
             <div className="relative w-11.25 h-8.25 mx-1.5 my-2" key={index}>


### PR DESCRIPTION
## Describe your changes
- Fix spacing between logos and description
- Fix alignment of logos on small devices
## Issue ticket number and link
- ID: 073
- Link: [Notion](https://www.notion.so/apeunit/Desktop-Mobile-Partners-Section-Paddings-912b866ddfb841afb05158312199f040?pvs=4)

## Tasks completed
- [x] Fix spacing between logos and description
- [x] Fix alignment of logos on small devices
 
## Tasks not completed
- None

## Screenshots (if needed)
