### PR TITLE
fix: make logos redirect to the respective links

### DIFF
--- a/components/sections/Partners.jsx
+++ b/components/sections/Partners.jsx
@@ -10,7 +10,7 @@ const Partners = () => {
       <Paragraph className="text-center text-secondary-200">
         We partner with the leading brands
       </Paragraph>
-      <div className="md:flex flex-wrap justify-center mt-4.75 items-center hidden lg:mx-57.75">
+      <div className="md:flex flex-wrap justify-center mt-4.75 items-center hidden lg:mx-57.75 gap-x-6 gap-y-4">
         {logos.map((logo, index) => {
           return (
             <Link href={logo.link} key={index} target='_blank'>
@@ -20,16 +20,15 @@ const Partners = () => {
                 height={logo.Height}
                 src={logo.source}
                 alt="logo"
-                className="mx-3 my-2"
-              />
+              ></Image>
             </Link>
           );
         })}
       </div>
-      <div className="flex flex-wrap justify-center mt-6 w-full md:hidden">
+      <div className="flex flex-wrap justify-center mt-6 w-full md:hidden gap-y-4 gap-x-3">
         {logos.map((logo, index) => {
           return (
-            <div className="relative w-11.25 h-8.25 mx-1.5 my-2" key={index}>
+            <div className="relative w-11.25 h-8.25" key={index}>
               <Link href={logo.link} target='_blank'><Image src={logo.source} priority fill alt="logo" /></Link>
             </div>
           );

--- a/data/logos.js
+++ b/data/logos.js
@@ -39,7 +39,7 @@ const logos = [
         source: '/assets/images/lab3.svg',
         Width: '99',
         Height: '60',
-        link: 'https://www.figma.com/proto/RbdGsuKF8RyVnrP5TTxdnO/Lab3-Presentation?node-id=1515%3A232&starting-point-node-id=1515%3A232'
+        link: 'https://lab3.space/'
     },
     {
         id: 7,
@@ -60,7 +60,7 @@ const logos = [
         source: '/assets/images/unit8.svg',
         Width: '124',
         Height: '60',
-        link: 'https://u8-landing.netlify.app/'
+        link: 'https://unit8.apeunit.com/'
     }
 ];
 


### PR DESCRIPTION
## Describe your changes
made the logos redirect to the respective links on image click 
## Issue ticket number and link
- ID: 080
- Link: [Notion](https://www.notion.so/apeunit/Fix-Partners-section-3390be39c7d349a5a497d88dde6c82f3?pvs=4)

## Tasks completed
- [x] added lab3 and unit8 updated links
- [x] removed margins on every links and used gaps on the logos' container instead
 
## Tasks not completed
- None

## Screenshots (if needed)
